### PR TITLE
Add support for Big Query logging

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,5 @@
 {
-    "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "none",
+  "tabWidth": 2
 }

--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 # Google Ads Offline Conversion Tag for Google Tag Manager Server Container
 
-
 - Allows tracking and attribution of events that happened offline (e.g., in-store or over the phone).
 - Reports more accurate ROI.
 - Allows feeding 1st party data to Google and attribute conversions of those users who either opted out of tracking or used adBlockers.
 - Allows seeing behavior conversion tracking without event modeling data.
 
-**Conversion Action ID** - refers to the conversion ID you want to use to track offline conversions.
+## Parameters
 
-**Operating Customer Id** - Google Ads account ID.
+**Conversion Action ID** - refers to the Conversion ID you want to use to track offline conversions.
+
+**Operating Customer ID** - Google Ads account ID.
 
 **Customer ID** - your Google Ads MCC account ID.
 
-If you use stape, **add your Stape Container API Key**. You can find it in the sGTM container settings. If you do not use stape, add your Google Ads developer token.
+If you use Stape, **add your Stape Container API Key**. You can find it in the sGTM container settings. If you do not use Stape, add your Google Ads developer token.
 
-**Conversion Environment** - Conversion environment of the uploaded conversion
+**Conversion Environment** - Conversion environment of the uploaded conversion.
 
 **Conversion DateTime** - The date-time at which the conversion occurred. It must be after the click time. The timezone must be specified. The format is "yyyy-mm-dd hh:mm:ss+|-hh:mm", e.g., "2019-01-01 12:32:45-08:00". If not set, the current time will be used.
 
@@ -22,11 +23,11 @@ If you use stape, **add your Stape Container API Key**. You can find it in the s
 
 **Wbraid** - The click identifier for clicks associated with web conversions and originating from iOS devices starting with iOS14.
 
-**Gclid** - The Google click ID (gclid) is associated with this conversion.
+**Gclid** - The Google click ID (gclid) associated with this conversion.
 
-### Useful links:
+## Useful resources
 - https://stape.io/blog/google-ads-offline-conversion-using-server-gtm
+
 ## Open Source
 
-Google Ads Offline Conversion Tag for GTM Server Side is developing and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.
-
+The **Google Ads Offline Conversion Tag for GTM Server Side** is developed and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: "https://stape.io/"
 versions:
+  - sha: 34799009706e10a03d3472f261ddb4f9b80aa6df
+    changeNotes: Add support for BigQuery logging.
   - sha: 30d585a9569d27a77ddfbee8a2a2b67c97d105e7
     changeNotes: Getting Stape API key from headers.
   - sha: 4b06ca7c121f2908d84292a837b5704e1a61b42c

--- a/template.js
+++ b/template.js
@@ -14,9 +14,22 @@ const sha256Sync = require('sha256Sync');
 const Math = require('Math');
 const Object = require('Object');
 const getGoogleAuth = require('getGoogleAuth');
+const BigQuery = require('BigQuery');
 
-const isLoggingEnabled = determinateIsLoggingEnabled();
+/**********************************************************************************************/
+
 const traceId = getRequestHeader('trace-id');
+
+const eventData = getAllEventData();
+
+if (!isConsentGivenOrNotRequired()) {
+  return data.gtmOnSuccess();
+}
+
+const url = eventData.page_location || getRequestHeader('referer');
+if (url && url.lastIndexOf('https://gtm-msr.appspot.com/', 0) === 0) {
+  return data.gtmOnSuccess();
+}
 
 const postBody = getData();
 const postUrl = getUrl();
@@ -31,37 +44,33 @@ if (data.authFlow === 'stape') {
   return sendConversionRequest();
 }
 
+/**********************************************************************************************/
+// Vendor related functions
+
 function sendConversionRequestApi() {
-  if (isLoggingEnabled) {
-    logToConsole(
-      JSON.stringify({
-        Name: 'GAdsOfflineConversion',
-        Type: 'Request',
-        TraceId: traceId,
-        EventName: makeString(data.conversionActionId),
-        RequestMethod: 'POST',
-        RequestUrl: postUrl,
-        RequestBody: postBody,
-      })
-    );
-  }
+  log({
+    Name: 'GAdsOfflineConversion',
+    Type: 'Request',
+    TraceId: traceId,
+    EventName: makeString(data.conversionAction),
+    RequestMethod: 'POST',
+    RequestUrl: postUrl,
+    RequestBody: postBody
+  });
 
   sendHttpRequest(
     postUrl,
     (statusCode, headers, body) => {
-      if (isLoggingEnabled) {
-        logToConsole(
-          JSON.stringify({
-            Name: 'GAdsOfflineConversion',
-            Type: 'Response',
-            TraceId: traceId,
-            EventName: makeString(data.conversionActionId),
-            ResponseStatusCode: statusCode,
-            ResponseHeaders: headers,
-            ResponseBody: body,
-          })
-        );
-      };
+      log({
+        Name: 'GAdsOfflineConversion',
+        Type: 'Response',
+        TraceId: traceId,
+        EventName: makeString(data.conversionAction),
+        ResponseStatusCode: statusCode,
+        ResponseHeaders: headers,
+        ResponseBody: body
+      });
+
       if (statusCode >= 200 && statusCode < 400) {
         data.gtmOnSuccess();
       } else {
@@ -71,46 +80,50 @@ function sendConversionRequestApi() {
     {
       headers: {
         'Content-Type': 'application/json',
-        'login-customer-id': data.customerId,
-      }, method: 'POST'
+        'login-customer-id': data.customerId
+      },
+      method: 'POST'
     },
     JSON.stringify(postBody)
   );
 }
 
 function sendConversionRequest() {
-  if (isLoggingEnabled) {
-    logToConsole(
-      JSON.stringify({
-        Name: 'GAdsOfflineConversion',
-        Type: 'Request',
-        TraceId: traceId,
-        EventName: makeString(data.conversionActionId),
-        RequestMethod: 'POST',
-        RequestUrl: postUrl,
-        RequestBody: postBody,
-      })
-    );
-  }
+  log({
+    Name: 'GAdsOfflineConversion',
+    Type: 'Request',
+    TraceId: traceId,
+    EventName: makeString(data.conversionAction),
+    RequestMethod: 'POST',
+    RequestUrl: postUrl,
+    RequestBody: postBody
+  });
 
   sendHttpRequest(
-    postUrl, { headers: {'Content-Type': 'application/json', 'login-customer-id': data.customerId, 'developer-token': data.developerToken}, method: 'POST', authorization: auth}, JSON.stringify(postBody)
-  ).then((statusCode, headers, body) => {
-    if (isLoggingEnabled) {
-      logToConsole(
-        JSON.stringify({
-          Name: 'GAdsOfflineConversion',
-          Type: 'Response',
-          TraceId: traceId,
-          EventName: makeString(data.conversionActionId),
-          ResponseStatusCode: statusCode,
-          ResponseHeaders: headers,
-          ResponseBody: body,
-        })
-      );
-    };
-      
-    if (statusCode >= 200 && statusCode < 400) {
+    postUrl,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'login-customer-id': data.customerId,
+        'developer-token': data.developerToken
+      },
+      method: 'POST',
+      authorization: auth
+    },
+    JSON.stringify(postBody)
+  ).then((result) => {
+    // .then has to be used when the Authorization header is in use
+    log({
+      Name: 'GAdsOfflineConversion',
+      Type: 'Response',
+      TraceId: traceId,
+      EventName: makeString(data.conversionAction),
+      ResponseStatusCode: result.statusCode,
+      ResponseHeaders: result.headers,
+      ResponseBody: result.body
+    });
+
+    if (result.statusCode >= 200 && result.statusCode < 400) {
       data.gtmOnSuccess();
     } else {
       data.gtmOnFailure();
@@ -122,7 +135,9 @@ function getUrl() {
   if (data.authFlow === 'own') {
     const apiVersion = '18';
     return (
-      'https://googleads.googleapis.com/v' + apiVersion + '/customers/' +
+      'https://googleads.googleapis.com/v' +
+      apiVersion +
+      '/customers/' +
       enc(data.opCustomerId) +
       ':uploadClickConversions'
     );
@@ -143,18 +158,17 @@ function getUrl() {
 }
 
 function getData() {
-  const eventData = getAllEventData();
   let mappedData = {
     conversionEnvironment: data.conversionEnvironment,
     conversionAction:
       'customers/' +
       data.opCustomerId +
       '/conversionActions/' +
-      data.conversionAction,
+      data.conversionAction
   };
 
   if (data.customDataList) {
-    let customVariables = [];
+    const customVariables = [];
 
     data.customDataList.forEach((d) => {
       customVariables.push({
@@ -163,7 +177,7 @@ function getData() {
           data.opCustomerId +
           '/conversionCustomVariables/' +
           d.conversionCustomVariable,
-        value: d.value,
+        value: d.value
       });
     });
 
@@ -179,7 +193,7 @@ function getData() {
     conversions: [mappedData],
     partialFailure: true,
     validateOnly: false,
-    debugEnabled: data.debugEnabled || false,
+    debugEnabled: data.debugEnabled || false
   };
 }
 
@@ -202,12 +216,14 @@ function addConversionAttribution(eventData, mappedData) {
     mappedData.conversionDateTime = eventData.conversionDateTime;
   else mappedData.conversionDateTime = getConversionDateTime();
 
-  if(data.externalAttributionModel || data.externalAttributionCredit) {
+  if (data.externalAttributionModel || data.externalAttributionCredit) {
     mappedData.external_attribution_data = {};
-    if(data.externalAttributionCredit)
-      mappedData.external_attribution_data.external_attribution_credit = makeNumber(data.externalAttributionCredit);
-    if(data.externalAttributionModel)
-      mappedData.external_attribution_data.external_attribution_model = data.externalAttributionModel;
+    if (data.externalAttributionCredit)
+      mappedData.external_attribution_data.external_attribution_credit =
+        makeNumber(data.externalAttributionCredit);
+    if (data.externalAttributionModel)
+      mappedData.external_attribution_data.external_attribution_model =
+        data.externalAttributionModel;
   }
 
   return mappedData;
@@ -240,7 +256,7 @@ function addCartData(eventData, mappedData) {
     currencyFromItems = eventData.items[0].currency;
 
     eventData.items.forEach((d, i) => {
-      let item = {};
+      const item = {};
 
       if (d.item_id) item.productId = makeString(d.item_id);
       else if (d.id) item.productId = makeString(d.id);
@@ -337,21 +353,22 @@ function addUserIdentifiers(eventData, mappedData) {
   let addressInfo;
   let userIdentifiersMapped = [];
   let userEventData = {};
-  let usedIdentifiers = [];
-
+  const usedIdentifiers = [];
 
   if (getType(eventData.user_data) === 'object') {
-    userEventData = eventData.user_data || eventData.user_properties || eventData.user;
+    userEventData =
+      eventData.user_data || eventData.user_properties || eventData.user;
   }
 
   if (data.userDataList) {
-    let userIdentifiers = [];
+    const userIdentifiers = [];
 
     data.userDataList.forEach((d) => {
       const valueType = getType(d.value);
-      const isValidValue = ['undefined', 'null'].indexOf(valueType) === -1 && d.value !== '';
-      if(isValidValue) {
-        let identifier = {};
+      const isValidValue =
+        ['undefined', 'null'].indexOf(valueType) === -1 && d.value !== '';
+      if (isValidValue) {
+        const identifier = {};
         identifier[d.name] = hashData(d.name, d.value);
         identifier['userIdentifierSource'] = d.userIdentifierSource;
 
@@ -367,19 +384,21 @@ function addUserIdentifiers(eventData, mappedData) {
   else if (eventData.email) hashedEmail = eventData.email;
   else if (eventData.email_address) hashedEmail = eventData.email_address;
   else if (userEventData.email) hashedEmail = userEventData.email;
-  else if (userEventData.email_address) hashedEmail = userEventData.email_address;
+  else if (userEventData.email_address)
+    hashedEmail = userEventData.email_address;
 
   if (usedIdentifiers.indexOf('hashedEmail') === -1 && hashedEmail) {
     userIdentifiersMapped.push({
       hashedEmail: hashData('hashedEmail', hashedEmail),
-      userIdentifierSource: 'UNSPECIFIED',
+      userIdentifierSource: 'UNSPECIFIED'
     });
   }
 
   if (eventData.phone) hashedPhoneNumber = eventData.phone;
   else if (eventData.phone_number) hashedPhoneNumber = eventData.phone_number;
   else if (userEventData.phone) hashedPhoneNumber = userEventData.phone;
-  else if (userEventData.phone_number) hashedPhoneNumber = userEventData.phone_number;
+  else if (userEventData.phone_number)
+    hashedPhoneNumber = userEventData.phone_number;
 
   if (
     usedIdentifiers.indexOf('hashedPhoneNumber') === -1 &&
@@ -387,7 +406,7 @@ function addUserIdentifiers(eventData, mappedData) {
   ) {
     userIdentifiersMapped.push({
       hashedPhoneNumber: hashData('hashedPhoneNumber', hashedPhoneNumber),
-      userIdentifierSource: 'UNSPECIFIED',
+      userIdentifierSource: 'UNSPECIFIED'
     });
   }
 
@@ -396,7 +415,7 @@ function addUserIdentifiers(eventData, mappedData) {
   if (usedIdentifiers.indexOf('mobileId') === -1 && mobileId) {
     userIdentifiersMapped.push({
       mobileId: mobileId,
-      userIdentifierSource: 'UNSPECIFIED',
+      userIdentifierSource: 'UNSPECIFIED'
     });
   }
 
@@ -405,7 +424,7 @@ function addUserIdentifiers(eventData, mappedData) {
   if (usedIdentifiers.indexOf('thirdPartyUserId') === -1 && thirdPartyUserId) {
     userIdentifiersMapped.push({
       thirdPartyUserId: thirdPartyUserId,
-      userIdentifierSource: 'UNSPECIFIED',
+      userIdentifierSource: 'UNSPECIFIED'
     });
   }
 
@@ -414,7 +433,7 @@ function addUserIdentifiers(eventData, mappedData) {
   if (usedIdentifiers.indexOf('addressInfo') === -1 && addressInfo) {
     userIdentifiersMapped.push({
       addressInfo: addressInfo,
-      userIdentifierSource: 'UNSPECIFIED',
+      userIdentifierSource: 'UNSPECIFIED'
     });
   }
 
@@ -427,14 +446,6 @@ function addUserIdentifiers(eventData, mappedData) {
 
 function getConversionDateTime() {
   return convertTimestampToISO(getTimestampMillis());
-}
-
-function isHashed(value) {
-  if (!value) {
-    return false;
-  }
-
-  return makeString(value).match('^[A-Fa-f0-9]{64}$') !== null;
 }
 
 function hashData(key, value) {
@@ -454,7 +465,7 @@ function hashData(key, value) {
     });
   }
 
-  if(type === 'object') {
+  if (type === 'object') {
     return Object.keys(value).reduce((acc, val) => {
       acc[val] = hashData(key, value[val]);
       return acc;
@@ -478,7 +489,7 @@ function hashData(key, value) {
       .split(')')
       .join('');
   } else if (key === 'hashedEmail') {
-    let valueParts = value.split('@');
+    const valueParts = value.split('@');
 
     if (valueParts[1] === 'gmail.com' || valueParts[1] === 'googlemail.com') {
       value = valueParts[0].split('.').join('') + '@' + valueParts[1];
@@ -511,8 +522,8 @@ function convertTimestampToISO(timestamp) {
   timestamp = timestamp % fourYearsInMs;
 
   while (true) {
-    let isLeapYear = !(year % 4);
-    let nextTimestamp = timestamp - daysToMs(isLeapYear ? 366 : 365);
+    const isLeapYear = !(year % 4);
+    const nextTimestamp = timestamp - daysToMs(isLeapYear ? 366 : 365);
     if (nextTimestamp < 0) {
       break;
     }
@@ -527,7 +538,7 @@ function convertTimestampToISO(timestamp) {
 
   let month = 0;
   for (let i = 0; i < daysByMonth.length; i++) {
-    let msInThisMonth = daysToMs(daysByMonth[i]);
+    const msInThisMonth = daysToMs(daysByMonth[i]);
     if (timestamp > msInThisMonth) {
       timestamp = timestamp - msInThisMonth;
     } else {
@@ -535,13 +546,13 @@ function convertTimestampToISO(timestamp) {
       break;
     }
   }
-  let date = Math.ceil(timestamp / daysToMs(1));
+  const date = Math.ceil(timestamp / daysToMs(1));
   timestamp = timestamp - daysToMs(date - 1);
-  let hours = Math.floor(timestamp / hoursToMs(1));
+  const hours = Math.floor(timestamp / hoursToMs(1));
   timestamp = timestamp - hoursToMs(hours);
-  let minutes = Math.floor(timestamp / minToMs(1));
+  const minutes = Math.floor(timestamp / minToMs(1));
   timestamp = timestamp - minToMs(minutes);
-  let sec = Math.floor(timestamp / secToMs(1));
+  const sec = Math.floor(timestamp / secToMs(1));
 
   return (
     year +
@@ -557,6 +568,106 @@ function convertTimestampToISO(timestamp) {
     format(sec) +
     '+00:00'
   );
+}
+
+/**********************************************************************************************/
+// Helpers
+
+function isHashed(value) {
+  if (!value) return false;
+  return makeString(value).match('^[A-Fa-f0-9]{64}$') !== null;
+}
+
+function enc(data) {
+  data = data || '';
+  return encodeUriComponent(data);
+}
+
+function isConsentGivenOrNotRequired() {
+  if (data.adStorageConsent !== 'required') return true;
+  if (eventData.consent_state) return !!eventData.consent_state.ad_storage;
+  const xGaGcs = eventData['x-ga-gcs'] || ''; // x-ga-gcs is a string like "G110"
+  return xGaGcs[2] === '1';
+}
+
+function log(rawDataToLog) {
+  const logDestinationsHandlers = {};
+  if (determinateIsLoggingEnabled())
+    logDestinationsHandlers.console = logConsole;
+  if (determinateIsLoggingEnabledForBigQuery())
+    logDestinationsHandlers.bigQuery = logToBigQuery;
+
+  // Key mappings for each log destination
+  const keyMappings = {
+    // No transformation for Console is needed.
+    bigQuery: {
+      Name: 'tag_name',
+      Type: 'type',
+      TraceId: 'trace_id',
+      EventName: 'event_name',
+      RequestMethod: 'request_method',
+      RequestUrl: 'request_url',
+      RequestBody: 'request_body',
+      ResponseStatusCode: 'response_status_code',
+      ResponseHeaders: 'response_headers',
+      ResponseBody: 'response_body'
+    }
+  };
+
+  for (const logDestination in logDestinationsHandlers) {
+    const handler = logDestinationsHandlers[logDestination];
+    if (!handler) continue;
+
+    const mapping = keyMappings[logDestination];
+    const dataToLog = mapping ? {} : rawDataToLog;
+    // Map keys based on the log destination
+    if (mapping) {
+      for (const key in rawDataToLog) {
+        const mappedKey = mapping[key] || key; // Fallback to original key if no mapping exists
+        dataToLog[mappedKey] = rawDataToLog[key];
+      }
+    }
+
+    handler(dataToLog);
+  }
+}
+
+function logConsole(dataToLog) {
+  logToConsole(JSON.stringify(dataToLog));
+}
+
+function logToBigQuery(dataToLog) {
+  const connectionInfo = {
+    projectId: data.logBigQueryProjectId,
+    datasetId: data.logBigQueryDatasetId,
+    tableId: data.logBigQueryTableId
+  };
+
+  // timestamp is required.
+  dataToLog.timestamp = getTimestampMillis();
+
+  // Columns with type JSON need to be stringified.
+  ['request_body', 'response_headers', 'response_body'].forEach((p) => {
+    // The JSON.parse of GTM Sandboxed JS should not throw and should return undefined if parsing
+    // a malformed JSON. This would be great to parse stringified objects and arrays, so that it's not needed
+    // to convert them back into their original format in BigQuery.
+    // Although it does return undefined and permits the code to continue running,
+    // it throws an error after the execution is complete, making tests and the overall execution to show as failed.
+    // Ref: https://developers.google.com/tag-platform/tag-manager/server-side/api#json
+
+    // If someday this is fixed, the lines below can be changed to this one:
+    // dataToLog[p] = JSON.stringify(JSON.parse(dataToLog[p]) || dataToLog[p]);
+
+    dataToLog[p] = JSON.stringify(dataToLog[p]);
+  });
+
+  // assertApi doesn't work for 'BigQuery.insert()'. It's needed to convert BigQuery into a function when testing.
+  // Ref: https://gtm-gear.com/posts/gtm-templates-testing/
+  const bigquery =
+    getType(BigQuery) === 'function'
+      ? BigQuery() /* Only during Unit Tests */
+      : BigQuery;
+  bigquery.insert(connectionInfo, [dataToLog], { ignoreUnknownValues: true });
 }
 
 function determinateIsLoggingEnabled() {
@@ -581,7 +692,7 @@ function determinateIsLoggingEnabled() {
   return data.logType === 'always';
 }
 
-function enc(data) {
-  data = data || '';
-  return encodeUriComponent(data);
+function determinateIsLoggingEnabledForBigQuery() {
+  if (data.bigQueryLogType === 'no') return false;
+  return data.bigQueryLogType === 'always';
 }


### PR DESCRIPTION
Hi.

- Added support for BigQuery logging for the [GTMS-7](https://github.com/stape-io/gtm-standards/blob/main/standards/GTMS-7.md).
  - Now, the tag has only one entry point for logging, the `log` function. It receives the data in the format used by the `logToConsole` logs, and decides where to route the data to (only Console, only BigQuery, or both), based on the options the end-user chose in the template UI. It also transforms the data into the required BQ format.
- Added tests for both types of logs (Console and BigQuery).
- Added consent checks section to the UI ([GTMS-2](https://github.com/stape-io/gtm-standards/blob/main/standards/GTMS-2.md)).
- Updated the README.